### PR TITLE
Add a faucet client to talk to the coordinator

### DIFF
--- a/client/BUILD
+++ b/client/BUILD
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+
+go_binary(
+    name = "client",
+    srcs = ["client.go"],
+    deps = [
+        "//proto/service/coordinator:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
+)

--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"os"
+
+	pb_coordinator "dinowernli.me/faucet/proto/service/coordinator"
+
+	"github.com/Sirupsen/logrus"
+)
+
+func main() {
+	logger := logrus.New()
+	logger.Out = os.Stderr
+
+	_ = &pb_coordinator.ChangeValidationRequest{}
+
+	logger.Infof("Hello world")
+}

--- a/client/client.go
+++ b/client/client.go
@@ -12,7 +12,9 @@ func main() {
 	logger := logrus.New()
 	logger.Out = os.Stderr
 
-	_ = &pb_coordinator.ChangeValidationRequest{}
+	_ = &pb_coordinator.CheckRequest{}
+	// TODO(dino): Take a few command line args to populate the request body as
+	// well as to find the coordinator, then send request to coordinator.
 
 	logger.Infof("Hello world")
 }

--- a/coordinator/BUILD
+++ b/coordinator/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//proto/service/worker:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_x_net//context:go_default_library",
     ],
     visibility = ["//visibility:public"],

--- a/coordinator/BUILD
+++ b/coordinator/BUILD
@@ -6,6 +6,7 @@ go_library(
     deps = [
         "//config:go_default_library",
         "//proto/config:go_default_library",
+        "//proto/service/coordinator:go_default_library",
         "//proto/service/worker:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -5,6 +5,7 @@ import (
 
 	"dinowernli.me/faucet/config"
 	pb_config "dinowernli.me/faucet/proto/config"
+	pb_coordinator "dinowernli.me/faucet/proto/service/coordinator"
 	pb_worker "dinowernli.me/faucet/proto/service/worker"
 
 	"github.com/Sirupsen/logrus"
@@ -16,13 +17,18 @@ import (
 // coordinator service. The coordinator uses faucet workers it knows of in
 // order to make sure builds get executed.
 type Coordinator struct {
+	Service      *coordinatorService
 	logger       *logrus.Logger
 	configLoader config.Loader
 }
 
 // New creates a new coordinator, and is otherwise side-effect free.
 func New(logger *logrus.Logger, configLoader config.Loader) *Coordinator {
-	return &Coordinator{logger: logger, configLoader: configLoader}
+	return &Coordinator{
+		Service:      &coordinatorService{},
+		logger:       logger,
+		configLoader: configLoader,
+	}
 }
 
 func (c *Coordinator) Start() {
@@ -68,4 +74,15 @@ func (c *Coordinator) pollStatus(address string, done chan (bool)) {
 	c.logger.Infof("Got response: %v", response)
 
 	done <- true
+}
+
+type coordinatorService struct {
+}
+
+func (s *coordinatorService) ValidateChange(context.Context, *pb_coordinator.ChangeValidationRequest) (*pb_coordinator.ChangeValidationResponse, error) {
+	return nil, nil
+}
+
+func (s *coordinatorService) GetValidationStatus(context.Context, *pb_coordinator.ValidationStatusRequest) (*pb_coordinator.ValidationStatusResponse, error) {
+	return nil, nil
 }

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 )
 
 // Coordinator represents an agent in the system which implements the faucet
@@ -79,10 +80,15 @@ func (c *Coordinator) pollStatus(address string, done chan (bool)) {
 type coordinatorService struct {
 }
 
-func (s *coordinatorService) ValidateChange(context.Context, *pb_coordinator.ChangeValidationRequest) (*pb_coordinator.ChangeValidationResponse, error) {
-	return nil, nil
+func (s *coordinatorService) Check(context.Context, *pb_coordinator.CheckRequest) (*pb_coordinator.CheckResponse, error) {
+	// TODO(dino): Make up a check id, create a record for the check id.
+	// TODO(dino): Look at the repository at the requested revision, work out what need to be tested.
+	// TODO(dino): Pick a suitable worker (maximize caching potential), kick off the run.
+	// TODO(dino): Return the check id to the caller.
+	return nil, grpc.Errorf(codes.Unimplemented, "Check not implemented")
 }
 
-func (s *coordinatorService) GetValidationStatus(context.Context, *pb_coordinator.ValidationStatusRequest) (*pb_coordinator.ValidationStatusResponse, error) {
-	return nil, nil
+func (s *coordinatorService) GetStatus(context.Context, *pb_coordinator.StatusRequest) (*pb_coordinator.StatusResponse, error) {
+	// TODO(dino): Lookup the requested check id
+	return nil, grpc.Errorf(codes.Unimplemented, "Check not implemented")
 }

--- a/demo/BUILD
+++ b/demo/BUILD
@@ -7,6 +7,7 @@ go_binary(
         "//config:go_default_library",
         "//coordinator:go_default_library",
         "//proto/config:go_default_library",
+        "//proto/service/coordinator:go_default_library",
         "//proto/service/worker:go_default_library",
         "//worker:go_default_library",
         "@org_golang_google_grpc//:go_default_library",

--- a/demo/demo.go
+++ b/demo/demo.go
@@ -8,6 +8,7 @@ import (
 
 	"dinowernli.me/faucet/config"
 	"dinowernli.me/faucet/coordinator"
+	pb_coordinator "dinowernli.me/faucet/proto/service/coordinator"
 	pb_worker "dinowernli.me/faucet/proto/service/worker"
 	"dinowernli.me/faucet/worker"
 
@@ -41,23 +42,30 @@ func main() {
 	coordinator := coordinator.New(logger, loader)
 	logger.Infof("Created coordinator")
 
-	go startServer(logger, worker)
 	go coordinator.Start()
+
+	// TODO(dino): Add a channel to avoid the race where the coordinator is still
+	// starting by the time the first requests come in.
+	go startServer(logger, worker, coordinator)
 
 	// TODO(dino): Pass this into the other stuff as a shutdown channel.
 	shutdown := make(chan bool)
 	<-shutdown
 }
 
-func startServer(logger *logrus.Logger, worker *worker.Worker) {
+func startServer(logger *logrus.Logger, worker *worker.Worker, coordinator *coordinator.Coordinator) {
 	server := grpc.NewServer()
 	pb_worker.RegisterWorkerServer(server, worker.Service)
+	logger.Infof("Registered worker service")
+
+	pb_coordinator.RegisterCoordinatorServer(server, coordinator.Service)
+	logger.Infof("Registered coordinator service")
 
 	listen, err := net.Listen("tcp", fmt.Sprintf(":%v", workerPort))
 	if err != nil {
 		logger.Fatalf("Failed to listen: %v", err)
 	}
 
-	logger.Infof("Starting worker server on port %v", workerPort)
+	logger.Infof("Starting grpc server on port %v", workerPort)
 	server.Serve(listen)
 }

--- a/proto/service/coordinator/BUILD
+++ b/proto/service/coordinator/BUILD
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_library")
+
+go_proto_library(
+    name = "go_default_library",
+    srcs = ["coordinator.proto"],
+    visibility = ["//visibility:public"],
+    has_services = 1,
+)
+

--- a/proto/service/coordinator/coordinator.proto
+++ b/proto/service/coordinator/coordinator.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package faucet.service.coordinator;
+
+// A request to asynchronously perform the necessary validation for a change.
+message ChangeValidationRequest {
+  string workspace = 1;
+
+  // TODO(dino): Add revision.
+}
+
+message ChangeValidationResponse {
+  // A unique identifier for the ongoing validation.
+  string validation_id = 1;
+}
+
+message ValidationStatusRequest {
+  string validation_id = 1;
+}
+
+message ValidationStatusResponse {
+}
+
+service Coordinator {
+  rpc ValidateChange (ChangeValidationRequest) returns (ChangeValidationResponse);
+  rpc GetValidationStatus (ValidationStatusRequest) returns (ValidationStatusResponse);
+}

--- a/proto/service/coordinator/coordinator.proto
+++ b/proto/service/coordinator/coordinator.proto
@@ -2,26 +2,27 @@ syntax = "proto3";
 
 package faucet.service.coordinator;
 
-// A request to asynchronously perform the necessary validation for a change.
-message ChangeValidationRequest {
+// A request to asynchronously perform the necessary checks for a change.
+message CheckRequest {
   string workspace = 1;
 
-  // TODO(dino): Add revision.
+  // TODO(dino): Add changeset.
 }
 
-message ChangeValidationResponse {
-  // A unique identifier for the ongoing validation.
-  string validation_id = 1;
+message CheckResponse {
+  // A unique identifier for the ongoing check.
+  string check_id = 1;
 }
 
-message ValidationStatusRequest {
-  string validation_id = 1;
+// A request for the status of a previously started check.
+message StatusRequest {
+  string check_id = 1;
 }
 
-message ValidationStatusResponse {
+message StatusResponse {
 }
 
 service Coordinator {
-  rpc ValidateChange (ChangeValidationRequest) returns (ChangeValidationResponse);
-  rpc GetValidationStatus (ValidationStatusRequest) returns (ValidationStatusResponse);
+  rpc Check (CheckRequest) returns (CheckResponse);
+  rpc GetStatus (StatusRequest) returns (StatusResponse);
 }


### PR DESCRIPTION
The faucet client is a thin wrapper around an rpc to the coordinator, triggering a build.

@hatstand